### PR TITLE
Added maxParallelForks to tests in gradle-plugin and integration-tests

### DIFF
--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -131,16 +131,19 @@ tasks.named("processTestResources").configure {
     dependsOn(writeTestPropsTask)
 }
 
+val cleanupTemporaryTestDir = tasks.register("cleanupTemporaryTestDir", Delete::class.java) {
+    delete = setOf(tempTestDir)
+}
+
 tasks.test {
+    dependsOn(cleanupTemporaryTestDir)
     dependsOn(":api:publishAllPublicationsToTestRepository")
     dependsOn(":gradle-plugin:publishAllPublicationsToTestRepository")
     dependsOn(":symbol-processing:publishAllPublicationsToTestRepository")
 
     jvmArgumentProviders.add(RelativizingLocalPathProvider("java.io.tmpdir", tempTestDir))
 
-    doFirst {
-        tempTestDir.deleteRecursively()
-    }
+    maxParallelForks = gradle.startParameter.maxWorkerCount / 2
 }
 
 abstract class WriteVersionSrcTask @Inject constructor(

--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -143,7 +143,7 @@ tasks.test {
 
     jvmArgumentProviders.add(RelativizingLocalPathProvider("java.io.tmpdir", tempTestDir))
 
-    maxParallelForks = gradle.startParameter.maxWorkerCount / 2
+    maxParallelForks = 2
 }
 
 abstract class WriteVersionSrcTask @Inject constructor(

--- a/integration-tests/build.gradle.kts
+++ b/integration-tests/build.gradle.kts
@@ -51,5 +51,5 @@ tasks.test {
         environment["JDK_9"] = launcher9.map { it.metadata.installationPath }
     }
 
-    maxParallelForks = gradle.startParameter.maxWorkerCount / 2
+    maxParallelForks = gradle.startParameter.maxWorkerCount
 }


### PR DESCRIPTION
Added maxParallelForks to tests in gradle-plugin and integration-tests. This will reduce testing time, as tests can be executed in parallel (not just the test tasks).